### PR TITLE
Renamed InstanceOptions to just Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ func main() {
         panic(err)
     }
 
-    f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+    f := featurevisor.CreateInstance(featurevisor.Options{
         Datafile: datafileContent,
     })
 }
@@ -135,7 +135,7 @@ import (
     "github.com/featurevisor/featurevisor-go"
 )
 
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     Context: featurevisor.Context{
         "deviceId": "123",
         "country":  "nl",
@@ -304,7 +304,7 @@ import (
     "github.com/featurevisor/featurevisor-go"
 )
 
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     Sticky: &StickyFeatures{
         "myFeatureKey": featurevisor.StickyFeature{
             Enabled: true,
@@ -428,7 +428,7 @@ import (
 )
 
 logLevel := featurevisor.LogLevelDebug
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     LogLevel: &logLevel,
 })
 ```
@@ -437,7 +437,7 @@ Alternatively, you can also set `logLevel` directly:
 
 ```go
 logLevel := featurevisor.LogLevelDebug
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     LogLevel: &logLevel,
 })
 ```
@@ -464,7 +464,7 @@ logger := featurevisor.NewLogger(featurevisor.CreateLoggerOptions{
     },
 })
 
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     Logger: logger,
 })
 ```
@@ -618,7 +618,7 @@ import (
     "github.com/featurevisor/featurevisor-go"
 )
 
-f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+f := featurevisor.CreateInstance(featurevisor.Options{
     Hooks: []*featurevisor.Hook{
         myCustomHook,
     },

--- a/api_compatibility_test.go
+++ b/api_compatibility_test.go
@@ -51,7 +51,7 @@ func TestAPICompatibilityWithStringFeatureKey(t *testing.T) {
 	}
 
 	// Create instance
-	instance := NewFeaturevisor(InstanceOptions{
+	instance := NewFeaturevisor(Options{
 		Datafile: datafile,
 		Context:  Context{"userId": "123"},
 	})
@@ -108,7 +108,7 @@ func TestAPICompatibilityWithStringFeatureKey(t *testing.T) {
 
 func TestAPICompatibilityWithNonExistentFeature(t *testing.T) {
 	// Create instance with empty datafile
-	instance := NewFeaturevisor(InstanceOptions{
+	instance := NewFeaturevisor(Options{
 		Datafile: DatafileContent{
 			SchemaVersion: "2",
 			Revision:      "test",
@@ -665,7 +665,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 	t.Run("allowSignup", func(t *testing.T) {
 		// Test Netherlands (NL) - should always get treatment variation
 		// Using bucket value 60000 (60%) to ensure we get treatment variation
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country":  "nl",
@@ -712,7 +712,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 		}
 
 		// Test Switzerland (CH) - should get treatment variation based on weight
-		instanceCH := NewFeaturevisor(InstanceOptions{
+		instanceCH := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country":  "ch",
@@ -735,7 +735,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 		}
 
 		// Test Germany (DE) - should get control variation in everyone segment
-		instanceDE := NewFeaturevisor(InstanceOptions{
+		instanceDE := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country":  "de",
@@ -762,7 +762,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 	t.Run("bar", func(t *testing.T) {
 		// Test with US context (should get control variation at low bucket values)
 		// Using bucket value 15000 (15%) to get control variation
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "us",
@@ -802,7 +802,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 
 		// Test with Germany context (should get variation 'b' with overrides)
 		// Using bucket value 20000 (20%) to get variation 'b'
-		instanceDE := NewFeaturevisor(InstanceOptions{
+		instanceDE := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "de",
@@ -829,7 +829,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 	t.Run("foo", func(t *testing.T) {
 		// Test with mobile + Germany context (should get treatment variation)
 		// Using bucket value 60000 (60%) to get treatment variation
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "de",
@@ -874,7 +874,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 		}
 
 		// Test force rule
-		instanceForce := NewFeaturevisor(InstanceOptions{
+		instanceForce := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"userId": "123",
@@ -905,7 +905,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 	t.Run("sidebar", func(t *testing.T) {
 		// Test with Netherlands context (should get treatment variation)
 		// Using bucket value 90000 (90%) to get treatment variation
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "nl",
@@ -958,7 +958,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 
 		// Test with Germany context (should get color override)
 		// Using bucket value 90000 (90%) to get treatment variation
-		instanceDE := NewFeaturevisor(InstanceOptions{
+		instanceDE := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "de",
@@ -990,7 +990,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 	t.Run("qux", func(t *testing.T) {
 		// Test with Netherlands context (should get variation 'b' based on allocation)
 		// Using bucket value 70000 (70%) to get variation 'b'
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "nl",
@@ -1025,7 +1025,7 @@ func TestProductionDatafileFeatures(t *testing.T) {
 
 		// Test with Germany context (should get variation 'b' based on allocation)
 		// Using bucket value 70000 (70%) to get variation 'b'
-		instanceDE := NewFeaturevisor(InstanceOptions{
+		instanceDE := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "de",
@@ -1095,7 +1095,7 @@ func TestProductionDatafileSegments(t *testing.T) {
 	// Test segment evaluation
 	t.Run("segmentEvaluation", func(t *testing.T) {
 		// Test Germany segment
-		instance := NewFeaturevisor(InstanceOptions{
+		instance := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "de",
@@ -1109,7 +1109,7 @@ func TestProductionDatafileSegments(t *testing.T) {
 		}
 
 		// Test Netherlands segment (should match because of everyone segment rule)
-		instanceNL := NewFeaturevisor(InstanceOptions{
+		instanceNL := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"country": "nl",
@@ -1123,7 +1123,7 @@ func TestProductionDatafileSegments(t *testing.T) {
 		}
 
 		// Test mobile segment
-		_ = NewFeaturevisor(InstanceOptions{
+		_ = NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"device": "mobile",
@@ -1132,7 +1132,7 @@ func TestProductionDatafileSegments(t *testing.T) {
 		})
 
 		// Test everyone segment
-		instanceEveryone := NewFeaturevisor(InstanceOptions{
+		instanceEveryone := NewFeaturevisor(Options{
 			Datafile: datafile,
 			Context: Context{
 				"userId": "test-user",

--- a/child.go
+++ b/child.go
@@ -1,7 +1,7 @@
 package featurevisor
 
-// ChildInstanceOptions contains options for creating a child instance
-type ChildInstanceOptions struct {
+// ChildOptions contains options for creating a child instance
+type ChildOptions struct {
 	Parent  *Featurevisor
 	Context Context
 	Sticky  *StickyFeatures
@@ -15,7 +15,7 @@ type FeaturevisorChild struct {
 }
 
 // NewFeaturevisorChild creates a new child instance
-func NewFeaturevisorChild(options ChildInstanceOptions) *FeaturevisorChild {
+func NewFeaturevisorChild(options ChildOptions) *FeaturevisorChild {
 	return &FeaturevisorChild{
 		parent:  options.Parent,
 		context: options.Context,

--- a/cmd/commands/assess_distribution.go
+++ b/cmd/commands/assess_distribution.go
@@ -117,7 +117,7 @@ func runAssessDistribution(opts CLIOptions) {
 		json.Unmarshal(datafileBytes, &datafileContent)
 	}
 
-	instance := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+	instance := featurevisor.CreateInstance(featurevisor.Options{
 		Datafile: datafileContent,
 		LogLevel: &level,
 	})

--- a/cmd/commands/benchmark.go
+++ b/cmd/commands/benchmark.go
@@ -176,7 +176,7 @@ func runBenchmark(opts CLIOptions) {
 	datafileSize := len(datafileBytes)
 	fmt.Printf("Datafile size: %.2f kB\n", float64(datafileSize)/1024.0)
 
-	instance := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+	instance := featurevisor.CreateInstance(featurevisor.Options{
 		Datafile: datafileContent,
 		LogLevel: &level,
 	})

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -699,7 +699,7 @@ func runTest(opts CLIOptions) {
 			}
 
 			levelStr := featurevisor.LogLevel(level)
-			instance := featurevisor.CreateInstance(featurevisor.InstanceOptions{
+			instance := featurevisor.CreateInstance(featurevisor.Options{
 				Datafile: datafileContent,
 				LogLevel: &levelStr,
 				Hooks: []*featurevisor.Hook{
@@ -755,7 +755,7 @@ func runTest(opts CLIOptions) {
 						}
 
 						levelStr := featurevisor.LogLevel(level)
-						instance = featurevisor.CreateInstance(featurevisor.InstanceOptions{
+						instance = featurevisor.CreateInstance(featurevisor.Options{
 							Datafile: datafileContent,
 							LogLevel: &levelStr,
 							Hooks: []*featurevisor.Hook{

--- a/instance.go
+++ b/instance.go
@@ -12,8 +12,8 @@ type OverrideOptions struct {
 	DefaultVariableValue  VariableValue
 }
 
-// InstanceOptions contains options for creating an instance
-type InstanceOptions struct {
+// Options contains options for creating an instance
+type Options struct {
 	Datafile interface{} // DatafileContent | string
 	Context  Context
 	LogLevel *LogLevel
@@ -36,7 +36,7 @@ type Featurevisor struct {
 }
 
 // NewFeaturevisor creates a new Featurevisor instance
-func NewFeaturevisor(options InstanceOptions) *Featurevisor {
+func NewFeaturevisor(options Options) *Featurevisor {
 	// Set default context
 	context := Context{}
 	if options.Context != nil {
@@ -264,7 +264,7 @@ func (i *Featurevisor) Spawn(args ...interface{}) *FeaturevisorChild {
 		}
 	}
 
-	return NewFeaturevisorChild(ChildInstanceOptions{
+	return NewFeaturevisorChild(ChildOptions{
 		Parent:  i,
 		Context: i.GetContext(contextValue),
 		Sticky:  optionsValue.Sticky,
@@ -626,6 +626,6 @@ func (i *Featurevisor) GetAllEvaluations(context Context, featureKeys []string, 
 }
 
 // CreateInstance creates a new Featurevisor instance
-func CreateInstance(options InstanceOptions) *Featurevisor {
+func CreateInstance(options Options) *Featurevisor {
 	return NewFeaturevisor(options)
 }

--- a/instance_deprecated_features_test.go
+++ b/instance_deprecated_features_test.go
@@ -75,7 +75,7 @@ func TestDeprecatedFeatures(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 		Logger:   customLogger,
 	})

--- a/instance_individually_named_segments_test.go
+++ b/instance_individually_named_segments_test.go
@@ -49,7 +49,7 @@ func TestIndividuallyNamedSegments(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 	})
 

--- a/instance_mutually_exclusive_test.go
+++ b/instance_mutually_exclusive_test.go
@@ -33,7 +33,7 @@ func TestMutuallyExclusiveFeatures(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Hooks: []*Hook{
 			{
 				Name: "unit-test",

--- a/instance_overridden_flags_test.go
+++ b/instance_overridden_flags_test.go
@@ -42,7 +42,7 @@ func TestOverriddenFlagsFromRules(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 	})
 

--- a/instance_required_features_test.go
+++ b/instance_required_features_test.go
@@ -44,7 +44,7 @@ func TestRequiredFeaturesSimple(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile1,
 	})
 
@@ -92,7 +92,7 @@ func TestRequiredFeaturesSimple(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk2 := CreateInstance(InstanceOptions{
+	sdk2 := CreateInstance(Options{
 		Datafile: datafile2,
 	})
 
@@ -153,7 +153,7 @@ func TestRequiredFeaturesWithVariation(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile1,
 	})
 
@@ -212,7 +212,7 @@ func TestRequiredFeaturesWithVariation(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk2 := CreateInstance(InstanceOptions{
+	sdk2 := CreateInstance(Options{
 		Datafile: datafile2,
 	})
 

--- a/instance_sticky_features_test.go
+++ b/instance_sticky_features_test.go
@@ -39,7 +39,7 @@ func TestStickyFeaturesInitialization(t *testing.T) {
 	}
 
 	// Create instance with sticky features and datafile
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafileContent,
 		Sticky: &StickyFeatures{
 			"test": EvaluatedFeature{
@@ -122,7 +122,7 @@ func TestStickyFeaturesInitialization(t *testing.T) {
 
 // TestSetStickyVariadicSignature tests that the new variadic signature works correctly
 func TestSetStickyVariadicSignature(t *testing.T) {
-	instance := CreateInstance(InstanceOptions{})
+	instance := CreateInstance(Options{})
 
 	// Test calling without replace parameter (should default to false)
 	sticky1 := StickyFeatures{"test1": EvaluatedFeature{Enabled: true}}

--- a/instance_test.go
+++ b/instance_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCreateInstance(t *testing.T) {
 	// Test that CreateInstance is a function
-	instance := CreateInstance(InstanceOptions{})
+	instance := CreateInstance(Options{})
 	if instance == nil {
 		t.Fatal("Expected instance to be created")
 	}
@@ -25,7 +25,7 @@ func TestCreateInstance(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance = CreateInstance(InstanceOptions{
+	instance = CreateInstance(Options{
 		Datafile: datafile,
 	})
 
@@ -78,7 +78,7 @@ func TestPlainBucketBy(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 		Hooks: []*Hook{
 			{
@@ -142,7 +142,7 @@ func TestAndBucketBy(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 		Hooks: []*Hook{
 			{
@@ -207,7 +207,7 @@ func TestOrBucketBy(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 		Hooks: []*Hook{
 			{
@@ -288,7 +288,7 @@ func TestBeforeHook(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 		Hooks: []*Hook{
 			{
@@ -362,7 +362,7 @@ func TestAfterHook(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 		Hooks: []*Hook{
 			{
@@ -500,7 +500,7 @@ func TestGetAllEvaluations(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	instance := CreateInstance(InstanceOptions{
+	instance := CreateInstance(Options{
 		Datafile: datafile,
 	})
 

--- a/instance_variables_no_variations_test.go
+++ b/instance_variables_no_variations_test.go
@@ -51,7 +51,7 @@ func TestVariablesWithoutVariations(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 	})
 

--- a/instance_variables_test.go
+++ b/instance_variables_test.go
@@ -112,7 +112,7 @@ func TestVariables(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 	})
 

--- a/instance_variations_test.go
+++ b/instance_variations_test.go
@@ -64,7 +64,7 @@ func TestVariationsWithForceRules(t *testing.T) {
 		t.Fatalf("Failed to parse datafile JSON: %v", err)
 	}
 
-	sdk := CreateInstance(InstanceOptions{
+	sdk := CreateInstance(Options{
 		Datafile: datafile,
 	})
 


### PR DESCRIPTION
## What's done

- Renamed `InstanceOptions` to just `Options`

## Comparison

### Before

```go
package main

import (
    "github.com/featurevisor/featurevisor-go"
)

func main() {
    f := featurevisor.CreateInstance(featurevisor.InstanceOptions{
        Datafile: featurevisor.DatafileContent.FromJSON("{ ... }"),
    })
}
```

### After

```go
package main

import (
    "github.com/featurevisor/featurevisor-go"
)

func main() {
    f := featurevisor.CreateInstance(featurevisor.Options{
        Datafile: featurevisor.DatafileContent.FromJSON("{ ... }"),
    })
}
```